### PR TITLE
Updating Makefile/.drone.yml to reflect current patterns in other plugins

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,13 +2,10 @@ build:
   image: golang:1.5
   environment:
     - GO15VENDOREXPERIMENT=1
-    - GOOS=linux
-    - GOARCH=amd64
-    - CGO_ENABLED=0
   commands:
-    - go get
-    - go build
-    - go test
+    - make deps
+    - make build
+    - make test
 
 publish:
   docker:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,25 @@
-BIN := drone-google-cloudstorage
-IMG ?= plugins/$(BIN)
+.PHONY: clean deps test build docker
 
-docker: $(BIN) Dockerfile
-	docker build --rm -t $(IMG) .
+export GOOS ?= linux
+export GOARCH ?= amd64
+export CGO_ENABLED ?= 0
 
-$(BIN): $(wildcard *.go)
-	GOOS=linux GOARCH=amd64 go build
+CI_BUILD_NUMBER ?= 0
+
+LDFLAGS += -X "main.buildDate=$(shell date -u '+%Y-%m-%d %H:%M:%S %Z')"
+LDFLAGS += -X "main.build=$(CI_BUILD_NUMBER)"
+
+clean:
+	go clean -i ./...
+
+deps:
+	go get -t ./...
+
+test:
+	go test -cover ./...
+
+build:
+	go build -ldflags '-s -w $(LDFLAGS)'
+
+docker:
+	docker build --rm=true -t plugins/drone-google-cloudstorage .


### PR DESCRIPTION
I ran into some issues when trying to build Docker images with the old Makefile:
```
$ docker run --rm -it plugins/drone-google-cloudstorage
no such file or directory
Error response from daemon: Cannot start container 616d22fc9506e847d990c076c1ebb232ad2f4598a9d9b91204e0f1b5db7d9a15: [8] System error: no such file or directory
```
The binary was present, but it looked like something was wrong with the linkage. I couldn't figure out specifically what was wrong, but noticed that I had no problem building most of the other more recent plugins. I compared Makefiles between the other plugins that were building+running correctly, only to find a different set of options being specified.

After updating drone-google-cloudstorage to reflect these new build params (the ldflags in particular), the builds started working.

**This PR updates .drone.yml, so the hash will change.**