### PR TITLE
Add mime types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk add --update ca-certificates && rm -rf /var/cache/apk/*
+RUN apk add --update mailcap ca-certificates && rm -rf /var/cache/apk/*
 
 ADD drone-google-cloudstorage /bin/
 ENTRYPOINT ["/bin/drone-google-cloudstorage"]


### PR DESCRIPTION
Alpine image doesn't provide `/etc/mime.types` out of the box, which is what Go's looking for in e.g. [mime.TypeByExtension](https://golang.org/pkg/mime/#TypeByExtension).

Without `/etc/mime.types` many files of "known" extensions are uploaded with `application/octet-stream` instead.

[mailcap](https://pkgs.alpinelinux.org/package/main/x86_64/mailcap) is the smallest package I could find.

R: @bradrydzewski