### PR TITLE
Renames

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,11 +32,11 @@ build_script:
       }
 
       docker pull microsoft/nanoserver:10.0.14393.1593
-      docker build -f Dockerfile.windows -t plugins/google-cloudstorage:windows-amd64 .
+      docker build -f Dockerfile.windows -t plugins/gcs:windows-amd64 .
 
 test_script:
   - ps: |
-      docker run --rm plugins/google-cloudstorage:windows-amd64 --version
+      docker run --rm plugins/gcs:windows-amd64 --version
 
 deploy_script:
   - ps: |
@@ -50,19 +50,19 @@ deploy_script:
         if ( $env:APPVEYOR_REPO_TAG -eq 'true' ) {
           $major,$minor,$patch = $env:APPVEYOR_REPO_TAG_NAME.substring(1).split('.')
 
-          docker push plugins/google-cloudstorage:windows-amd64
+          docker push plugins/gcs:windows-amd64
 
-          docker tag plugins/google-cloudstorage:windows-amd64 plugins/google-cloudstorage:$major.$minor.$patch-windows-amd64
-          docker push plugins/google-cloudstorage:$major.$minor.$patch-windows-amd64
+          docker tag plugins/gcs:windows-amd64 plugins/gcs:$major.$minor.$patch-windows-amd64
+          docker push plugins/gcs:$major.$minor.$patch-windows-amd64
 
-          docker tag plugins/google-cloudstorage:windows-amd64 plugins/google-cloudstorage:$major.$minor-windows-amd64
-          docker push plugins/google-cloudstorage:$major.$minor-windows-amd64
+          docker tag plugins/gcs:windows-amd64 plugins/gcs:$major.$minor-windows-amd64
+          docker push plugins/gcs:$major.$minor-windows-amd64
 
-          docker tag plugins/google-cloudstorage:windows-amd64 plugins/google-cloudstorage:$major-windows-amd64
-          docker push plugins/google-cloudstorage:$major-windows-amd64
+          docker tag plugins/gcs:windows-amd64 plugins/gcs:$major-windows-amd64
+          docker push plugins/gcs:$major-windows-amd64
         } else {
           if ( $env:APPVEYOR_REPO_BRANCH -eq 'master' ) {
-            docker push plugins/google-cloudstorage:windows-amd64
+            docker push plugins/gcs:windows-amd64
           }
         }
       }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ version: '{build}'
 image: 'Visual Studio 2017'
 platform: 'x64'
 
-clone_folder: 'c:\gopath\src\github.com\drone-plugins\drone-google-cloudstorage'
+clone_folder: 'c:\gopath\src\github.com\drone-plugins\drone-gcs'
 max_jobs: 1
 
 environment:
@@ -25,10 +25,10 @@ build_script:
       dep ensure
 
       if ( $env:APPVEYOR_REPO_TAG -eq 'false' ) {
-        go build -ldflags "-X main.build=$env:APPVEYOR_BUILD_VERSION" -a -o release/drone-google-cloudstorage.exe
+        go build -ldflags "-X main.build=$env:APPVEYOR_BUILD_VERSION" -a -o release/drone-gcs.exe
       } else {
         $version = $env:APPVEYOR_REPO_TAG_NAME.substring(1)
-        go build -ldflags "-X main.version=$version -X main.build=$env:APPVEYOR_BUILD_VERSION" -a -o release/drone-google-cloudstorage.exe
+        go build -ldflags "-X main.version=$version -X main.build=$env:APPVEYOR_BUILD_VERSION" -a -o release/drone-gcs.exe
       }
 
       docker pull microsoft/nanoserver:10.0.14393.1593

--- a/.drone.yml
+++ b/.drone.yml
@@ -87,7 +87,7 @@ pipeline:
     pull: true
     secrets: [ docker_username, docker_password ]
     group: docker
-    repo: plugins/google-cloudstorage
+    repo: plugins/gcs
     auto_tag: true
     auto_tag_suffix: linux-amd64
     dockerfile: Dockerfile
@@ -99,7 +99,7 @@ pipeline:
     pull: true
     secrets: [ docker_username, docker_password ]
     group: docker
-    repo: plugins/google-cloudstorage
+    repo: plugins/gcs
     auto_tag: true
     auto_tag_suffix: linux-i386
     dockerfile: Dockerfile.i386
@@ -111,7 +111,7 @@ pipeline:
     pull: true
     secrets: [ docker_username, docker_password ]
     group: docker
-    repo: plugins/google-cloudstorage
+    repo: plugins/gcs
     auto_tag: true
     auto_tag_suffix: linux-arm64
     dockerfile: Dockerfile.arm64
@@ -123,7 +123,7 @@ pipeline:
     pull: true
     secrets: [ docker_username, docker_password ]
     group: docker
-    repo: plugins/google-cloudstorage
+    repo: plugins/gcs
     auto_tag: true
     auto_tag_suffix: linux-arm
     dockerfile: Dockerfile.arm

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 workspace:
   base: /go
-  path: src/github.com/drone-plugins/drone-google-cloudstorage
+  path: src/github.com/drone-plugins/drone-gcs
 
 pipeline:
   deps:
@@ -28,9 +28,9 @@ pipeline:
     commands:
       - |
         if test "${DRONE_TAG}" = ""; then
-          go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/amd64/drone-google-cloudstorage
+          go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/amd64/drone-gcs
         else
-          go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/amd64/drone-google-cloudstorage
+          go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/amd64/drone-gcs
         fi
 
   build_linux_i386:
@@ -44,9 +44,9 @@ pipeline:
     commands:
       - |
         if test "${DRONE_TAG}" = ""; then
-          go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/i386/drone-google-cloudstorage
+          go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/i386/drone-gcs
         else
-          go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/i386/drone-google-cloudstorage
+          go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/i386/drone-gcs
         fi
 
   build_linux_arm64:
@@ -60,9 +60,9 @@ pipeline:
     commands:
       - |
         if test "${DRONE_TAG}" = ""; then
-          go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm64/drone-google-cloudstorage
+          go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm64/drone-gcs
         else
-          go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm64/drone-google-cloudstorage
+          go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm64/drone-gcs
         fi
 
   build_linux_arm:
@@ -77,9 +77,9 @@ pipeline:
     commands:
       - |
         if test "${DRONE_TAG}" = ""; then
-          go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm/drone-google-cloudstorage
+          go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm/drone-gcs
         else
-          go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm/drone-google-cloudstorage
+          go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm/drone-gcs
         fi
 
   publish_linux_amd64:

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ release/
 vendor/
 
 coverage.out
-drone-google-cloudstorage
+drone-gcs

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-ADD release/linux/amd64/drone-google-cloudstorage /bin/
-ENTRYPOINT ["/bin/drone-google-cloudstorage"]
+ADD release/linux/amd64/drone-gcs /bin/
+ENTRYPOINT ["/bin/drone-gcs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM plugins/base:multiarch
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
-  org.label-schema.name="Drone Google Cloudstorage" \
+  org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -5,5 +5,5 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-ADD release/linux/arm/drone-google-cloudstorage /bin/
-ENTRYPOINT [ "/bin/drone-google-cloudstorage" ]
+ADD release/linux/arm/drone-gcs /bin/
+ENTRYPOINT [ "/bin/drone-gcs" ]

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,7 +1,7 @@
 FROM plugins/base:multiarch
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
-  org.label-schema.name="Drone Google Cloudstorage" \
+  org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -5,5 +5,5 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-ADD release/linux/arm64/drone-google-cloudstorage /bin/
-ENTRYPOINT [ "/bin/drone-google-cloudstorage" ]
+ADD release/linux/arm64/drone-gcs /bin/
+ENTRYPOINT [ "/bin/drone-gcs" ]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,7 +1,7 @@
 FROM plugins/base:multiarch
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
-  org.label-schema.name="Drone Google Cloudstorage" \
+  org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 

--- a/Dockerfile.i386
+++ b/Dockerfile.i386
@@ -5,5 +5,5 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 
-ADD release/linux/i386/drone-google-cloudstorage /bin/
-ENTRYPOINT ["/bin/drone-google-cloudstorage"]
+ADD release/linux/i386/drone-gcs /bin/
+ENTRYPOINT ["/bin/drone-gcs"]

--- a/Dockerfile.i386
+++ b/Dockerfile.i386
@@ -1,7 +1,7 @@
 FROM plugins/base:multiarch
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
-  org.label-schema.name="Drone Google Cloudstorage" \
+  org.label-schema.name="Drone GCS" \
   org.label-schema.vendor="Drone.IO Community" \
   org.label-schema.schema-version="1.0"
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -2,7 +2,7 @@
 FROM microsoft/nanoserver:10.0.14393.1593
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
-  org.label-schema.name="Drone Google Cloudstorage" `
+  org.label-schema.name="Drone GCS" `
   org.label-schema.vendor="Drone.IO Community" `
   org.label-schema.schema-version="1.0"
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -8,5 +8,5 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ADD release\drone-google-cloudstorage.exe c:\drone-google-cloudstorage.exe
-ENTRYPOINT [ "c:\\drone-google-cloudstorage.exe" ]
+ADD release\drone-gcs.exe c:\drone-gcs.exe
+ENTRYPOINT [ "c:\\drone-gcs.exe" ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# drone-google-cloudstorage
+# drone-gcs
 
-[![Build Status](http://beta.drone.io/api/badges/drone-plugins/drone-google-cloudstorage/status.svg)](http://beta.drone.io/drone-plugins/drone-google-cloudstorage)
-[![Coverage Status](https://aircover.co/badges/drone-plugins/drone-google-cloudstorage/coverage.svg)](https://aircover.co/drone-plugins/drone-google-cloudstorage)
+[![Build Status](http://beta.drone.io/api/badges/drone-plugins/drone-gcs/status.svg)](http://beta.drone.io/drone-plugins/drone-gcs)
+[![Coverage Status](https://aircover.co/badges/drone-plugins/drone-gcs/coverage.svg)](https://aircover.co/drone-plugins/drone-gcs)
 [![](https://badge.imagelayers.io/plugins/drone-gcs:latest.svg)](https://imagelayers.io/?images=plugins/drone-gcs:latest 'Get your own badge on imagelayers.io')
 
 Drone plugin to publish files and artifacts to Google Cloud Storage. For the usage information and a listing of the available options please take a look at [the docs](DOCS.md).
@@ -17,7 +17,7 @@ make deps build
 ### Example
 
 ```sh
-./drone-google-cloudstorage <<EOF
+./drone-gcs <<EOF
 {
     "repo": {
         "clone_url": "git://github.com/drone/drone",
@@ -77,7 +77,7 @@ make deps docker
 ### Example
 
 ```sh
-docker run -i plugins/drone-google-cloudstorage <<EOF
+docker run -i plugins/drone-gcs <<EOF
 {
     "repo": {
         "clone_url": "git://github.com/drone/drone",

--- a/manifest.tmpl
+++ b/manifest.tmpl
@@ -1,4 +1,4 @@
-image: plugins/google-cloudstorage:{{#if build.tag}}{{trimPrefix build.tag "v"}}{{else}}latest{{/if}}
+image: plugins/gcs:{{#if build.tag}}{{trimPrefix build.tag "v"}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,27 +7,27 @@ tags:
 {{/if}}
 manifests:
   -
-    image: plugins/google-cloudstorage:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}linux-amd64
+    image: plugins/gcs:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: plugins/google-cloudstorage:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}linux-i386
+    image: plugins/gcs:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}linux-i386
     platform:
       architecture: 386
       os: linux
   -
-    image: plugins/google-cloudstorage:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}linux-arm64
+    image: plugins/gcs:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}linux-arm64
     platform:
       architecture: arm64
       os: linux
   -
-    image: plugins/google-cloudstorage:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}linux-arm
+    image: plugins/gcs:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}linux-arm
     platform:
       architecture: arm
       os: linux
   -
-    image: plugins/google-cloudstorage:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}windows-amd64
+    image: plugins/gcs:{{#if build.tag}}{{trimPrefix build.tag "v"}}-{{/if}}windows-amd64
     platform:
       architecture: amd64
       os: windows


### PR DESCRIPTION
This should be merged before #12.

`google-cloudstorage` should really be `gcs` or `google-cloud-storage`.

Since google container registry is gcr, I renamed this to gcs.

TODO:

- [ ] rename repository on github
- [ ] reconnect CI in beta.drone.io

Also, trying to clarify between:

- https://hub.docker.com/r/plugins/gcs/
- https://hub.docker.com/r/plugins/drone-gcs/ (assuming this one is outdated, should it be deleted? Not sure what the source of that is.)